### PR TITLE
fix start of local registry (image name missing)

### DIFF
--- a/fetch-image-from-docker-hub-with-intermediate-registry.sh
+++ b/fetch-image-from-docker-hub-with-intermediate-registry.sh
@@ -4,7 +4,7 @@ set -ue
 IMAGE=$1
 TAG=$2
 
-curl localhost:5000 || docker run -d -p 5000:5000
+curl localhost:5000 || docker run -d -p 5000:5000 registry:2
 REGISTRY=localhost:5000
 
 docker pull $IMAGE:$TAG


### PR DESCRIPTION
Fixes error when running `./fetch-image-from-docker-hub-with-intermediate-registry.sh alpine latest`

```
"docker run" requires at least 1 argument.
```