### PR TITLE
Fix //-path issue on MacOS

### DIFF
--- a/reg2bucket.sh
+++ b/reg2bucket.sh
@@ -15,7 +15,7 @@ aws s3 $ENDPOINT cp v2/ s3://$BUCKET/v2/ \
   --acl public-read \
   --recursive --exclude '*/manifests/*'
 
-for MANIFEST in $(find v2/ -path '*/manifests/*'); do
+for MANIFEST in $(find v2 -path '*/manifests/*'); do
   CONTENT_TYPE=$(jq -r .mediaType < $MANIFEST)
   aws s3 $ENDPOINT cp $MANIFEST s3://$BUCKET/$MANIFEST \
     --acl public-read \


### PR DESCRIPTION
Unlike GNU findutils (i.e. "find"), MacOS' "find" utility returns paths with a "//", e.g.
```
v2//alpine/manifests/sha256:c74f1b...
```
Without the trailing slash, both of these "find" utilities now return the expected result.