### PR TITLE
Add Apache2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ the registry code, using almost any static file hosting service.
 For instance:
 
 - a plain NGINX server (without LUA, JSX, or whatever custom module)
+- a plain Apache2 server (using `.htaccess` overrides)
 - the [Netlify] CDN
 - an object store like S3, or a compatible one like [R2] or [Scaleway]
 
@@ -105,6 +106,20 @@ docker-compose up
 ```
 
 The image will be available as `localhost:5555/$IMAGE:$TAG`.
+
+
+### Apache2 server
+
+Generate a `.htaccess` file in `./v2/` folder. This configuration file will
+set `content-type` HTTP headers.
+
+```bash
+./gen-apache2.sh
+```
+
+You may upload `./v2/` folder to the server root of an existing Apache2 server.
+Module `headers_module` must be available and `.htaccess` overrides enabled in
+server configuration.
 
 
 ### Netlify

--- a/gen-apache2.sh
+++ b/gen-apache2.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -ue
+
+cp error.json v2/
+echo "ErrorDocument 404 /v2/error.json" >"v2/.htaccess"
+
+for MANIFEST_DIR in v2/*/manifests; do
+  (
+    # Set content type
+    for FILE in $(find "$MANIFEST_DIR" -type f -not -name .htaccess); do
+      CONTENT_TYPE=$(jq -r .mediaType "$FILE")
+      if [ "$CONTENT_TYPE" = "null" ]; then
+        CONTENT_TYPE="application/vnd.docker.distribution.manifest.v1+prettyjws"
+      fi
+      echo "<Files $(basename "$FILE")>"
+      echo "  ForceType $CONTENT_TYPE"
+      echo "</Files>"
+    done
+
+    # Add Docker-Content-Digest header to tags
+    for FILE in $(find "$MANIFEST_DIR" -type f -not -name .htaccess -not -name 'sha256*'); do
+      sha256=$(sha256sum "$FILE" | cut -d ' ' -f1)
+      echo "<Files $(basename "$FILE")>"
+      echo "  Header add Docker-Content-Digest sha256:$sha256"
+      echo "</Files>"
+    done
+  )>"$MANIFEST_DIR/.htaccess"
+done


### PR DESCRIPTION
Taking inspiration from NGINX configuration, a static registry can be hosted using Apache2.
This enables users to host static Docker registries on most PHP web hosting services.

(Thank you for this awesome project!)